### PR TITLE
bugfix: cJSON_delete the memory from cJSON_create

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,12 @@ sudo: true
 dist: trusty
 language: c
 before_install:
-  - sudo apt-get install -y libev-dev build-essential cpanminus perlmagick 
+  - sudo apt-get install -y libev-dev build-essential cpanminus perlmagick
   - wget http://nginx.org/download/nginx-1.11.7.tar.gz
   - tar -zxf nginx-1.11.7.tar.gz
+  - wget https://github.com/lighttpd/weighttp/archive/weighttp-0.4.tar.gz
+  - tar -zxf weighttp-0.4.tar.gz
+  - (cd weighttp-weighttp-0.4 && ./autogen.sh && ./configure && make && sudo make install)
 script:
   - (cd nginx-1.11.7 && ./configure --add-module=$(dirname $(pwd)) && make -j4 && sudo make install)
   - sudo cpanm Test::Nginx

--- a/ngx_http_ipip_module.c
+++ b/ngx_http_ipip_module.c
@@ -578,6 +578,9 @@ ngx_http_ipip_ip_handler(ngx_http_request_t *r)
         ngx_memcpy(buf, NGX_HTTP_IPIP_EMPTY_RESPONSE, sizeof(NGX_HTTP_IPIP_EMPTY_RESPONSE));
 
     } else {
+        /*
+         * remember to free by cJSON_Delete
+         */
         root = cJSON_CreateObject();
         cJSON_AddStringToObject(root, "ret", "ok");
         cJSON_AddItemToObject(root, "data", data = cJSON_CreateArray());
@@ -589,6 +592,7 @@ ngx_http_ipip_ip_handler(ngx_http_request_t *r)
 
                 tmpbuf = ngx_pcalloc(r->pool, p - lastp);
                 if (tmpbuf == NULL) {
+                    cJSON_Delete(root);
                     return NGX_HTTP_INTERNAL_SERVER_ERROR;
                 }
 
@@ -602,6 +606,7 @@ ngx_http_ipip_ip_handler(ngx_http_request_t *r)
 
             tmpbuf = ngx_pcalloc(r->pool, p - lastp);
             if (tmpbuf == NULL) {
+                cJSON_Delete(root);
                 return NGX_HTTP_INTERNAL_SERVER_ERROR;
             }
 
@@ -609,7 +614,12 @@ ngx_http_ipip_ip_handler(ngx_http_request_t *r)
             cJSON_AddStringToObject(data, "dummy", (char *)tmpbuf);
         }
 
-        ngx_http_ipip_json_stringify(r, root, &buf, &len);
+        if (ngx_http_ipip_json_stringify(r, root, &buf, &len) != NGX_OK) {
+            cJSON_Delete(root);
+            return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        }
+
+        cJSON_Delete(root);
     }
 
     r->headers_out.content_length_n = strlen((char *)buf);
@@ -699,6 +709,7 @@ ngx_http_ipip_phone_handler(ngx_http_request_t *r)
 
                 tmpbuf = ngx_pcalloc(r->pool, p - lastp);
                 if (tmpbuf == NULL) {
+                    cJSON_Delete(root);
                     return NGX_HTTP_INTERNAL_SERVER_ERROR;
                 }
 
@@ -712,6 +723,7 @@ ngx_http_ipip_phone_handler(ngx_http_request_t *r)
 
             tmpbuf = ngx_pcalloc(r->pool, p - lastp);
             if (tmpbuf == NULL) {
+                cJSON_Delete(root);
                 return NGX_HTTP_INTERNAL_SERVER_ERROR;
             }
 
@@ -719,7 +731,12 @@ ngx_http_ipip_phone_handler(ngx_http_request_t *r)
             cJSON_AddStringToObject(data, "dummy", (char *)tmpbuf);
         }
 
-        ngx_http_ipip_json_stringify(r, root, &buf, &len);
+        if (ngx_http_ipip_json_stringify(r, root, &buf, &len) != NGX_OK) {
+            cJSON_Delete(root);
+            return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        }
+
+        cJSON_Delete(root);
     }
 
     r->headers_out.content_length_n = strlen((char *)buf);

--- a/ngx_http_ipip_module.c
+++ b/ngx_http_ipip_module.c
@@ -59,9 +59,9 @@ static void *ngx_http_ipip_create_loc_conf(ngx_conf_t *cf);
 static char *ngx_http_ipip_ip_datx(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 static char *ngx_http_ipip_phone_txt(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 static char *ngx_http_ipip_enable(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
-static ngx_int_t ngx_http_ipip_ip_lookup(ngx_http_ipip_ip_datx_t *datx, char *ip, u_char *result);
-static ngx_int_t
-ngx_http_ipip_phone_lookup(ngx_http_ipip_phone_txt_t *txt, u_char *phone, u_char *result);
+static ngx_int_t ngx_http_ipip_ip_lookup(ngx_http_ipip_ip_datx_t *datx, u_char *ip, u_char *result);
+static ngx_int_t ngx_http_ipip_phone_lookup(ngx_http_ipip_phone_txt_t *txt,
+                                            u_char *phone, u_char *result);
 static ngx_int_t ngx_http_ipip_handler(ngx_http_request_t *r);
 static ngx_int_t ngx_http_ipip_json_stringify(ngx_http_request_t *r,
                                     cJSON *root, u_char **buf, ssize_t *len);
@@ -441,17 +441,17 @@ ngx_http_ipip_phone_lookup(ngx_http_ipip_phone_txt_t *txt, u_char *phone, u_char
 
 
 static ngx_int_t
-ngx_http_ipip_ip_lookup(ngx_http_ipip_ip_datx_t *datx, char *ip, u_char *result)
+ngx_http_ipip_ip_lookup(ngx_http_ipip_ip_datx_t *datx, u_char *ip, u_char *result)
 {
-    ngx_uint_t ips[4];
+    u_char     ips[4];
     ngx_uint_t ip_prefix_value, ip2long_value, start, max_comp_len, index_offset, index_length;
 
     if (datx->addr == NULL) {
         return NGX_ERROR;
     }
 
-    if (sscanf(ip, "%u.%u.%u.%u", (unsigned int *)&ips[0], (unsigned int *)&ips[1],
-               (unsigned int *)&ips[2], (unsigned int *)&ips[3]) != 4)
+    if (sscanf((const char *)ip, "%hhu.%hhu.%hhu.%hhu", &ips[0], &ips[1],
+               &ips[2], &ips[3]) != 4)
     {
         return NGX_ERROR;
     }
@@ -567,7 +567,7 @@ ngx_http_ipip_ip_handler(ngx_http_request_t *r)
 
     */
 
-    rc = ngx_http_ipip_ip_lookup(&imcf->ip_datx, (char *)arg.data, result);
+    rc = ngx_http_ipip_ip_lookup(&imcf->ip_datx, arg.data, result);
     if (rc != NGX_OK) {
 
         buf = ngx_pcalloc(r->pool, sizeof(NGX_HTTP_IPIP_EMPTY_RESPONSE));

--- a/t/03-memoryleak.t
+++ b/t/03-memoryleak.t
@@ -1,18 +1,35 @@
-use Test::Nginx::Socket 'no_plan';
-
 BEGIN {
     $ENV{TEST_NGINX_CHECK_LEAK} = 1;
 }
 
+use Test::Nginx::Socket 'no_plan';
+
+
 my $workdir = $ENV{WORKDIR};
 
-repeat_each(1024);
+our $http_config;
+
+if (-f '$workdir/fixtures/real_ip.datx') {
+    $http_config = <<"_EOC_";
+        ipip_ip_datx '$workdir/fixtures/real_ip.datx';
+        ipip_phone_txt '$workdir/fixtures/real_phone.txt';
+_EOC_
+
+} else {
+    $http_config = <<"_EOC_";
+        ipip_ip_datx '$workdir/fixtures/fake_ip.datx';
+        ipip_phone_txt '$workdir/fixtures/fake_phone.txt';
+_EOC_
+}
+
+repeat_each(4096);
 no_shuffle();
 run_tests();
 
 __DATA__
 
 === TEST 1: test empty ip datx should do not leak memory
+--- http_config eval: $::http_config
 --- config
 location /ip {
     ipip on;
@@ -20,8 +37,5 @@ location /ip {
 
 --- request
 GET /ip?ip=8.8.8.8
-
---- response_body eval
-'{"ret": "ok", "data": []}'
 
 --- error_code: 200

--- a/t/03-memoryleak.t
+++ b/t/03-memoryleak.t
@@ -1,0 +1,27 @@
+use Test::Nginx::Socket 'no_plan';
+
+BEGIN {
+    $ENV{TEST_NGINX_CHECK_LEAK} = 1;
+}
+
+my $workdir = $ENV{WORKDIR};
+
+repeat_each(1024);
+no_shuffle();
+run_tests();
+
+__DATA__
+
+=== TEST 1: test empty ip datx should do not leak memory
+--- config
+location /ip {
+    ipip on;
+}
+
+--- request
+GET /ip?ip=8.8.8.8
+
+--- response_body eval
+'{"ret": "ok", "data": []}'
+
+--- error_code: 200


### PR DESCRIPTION
cJSON_create do allocate the memory on heap and the caller should ensure destroy the memory by cJSON_delete